### PR TITLE
Provides jvm-application-package instead of jvm-application

### DIFF
--- a/gradle/detect.go
+++ b/gradle/detect.go
@@ -24,6 +24,12 @@ import (
 	"github.com/buildpacks/libcnb"
 )
 
+const (
+	PlanEntryGradle                = "gradle"
+	PlanEntryJVMApplicationPackage = "jvm-application-package"
+	PlaneEntryJDK                  = "jdk"
+)
+
 type Detect struct{}
 
 func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
@@ -45,12 +51,12 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 			Plans: []libcnb.BuildPlan{
 				{
 					Provides: []libcnb.BuildPlanProvide{
-						{Name: "gradle"},
-						{Name: "jvm-application"},
+						{Name: PlanEntryGradle},
+						{Name: PlanEntryJVMApplicationPackage},
 					},
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: "gradle"},
-						{Name: "jdk"},
+						{Name: PlanEntryGradle},
+						{Name: PlaneEntryJDK},
 					},
 				},
 			},

--- a/gradle/detect_test.go
+++ b/gradle/detect_test.go
@@ -61,7 +61,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "gradle"},
-						{Name: "jvm-application"},
+						{Name: "jvm-application-package"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "gradle"},
@@ -81,7 +81,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "gradle"},
-						{Name: "jvm-application"},
+						{Name: "jvm-application-package"},
 					},
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "gradle"},


### PR DESCRIPTION
Changes name of provided plan entry to draw a distinction between a runnable JVM application (mostly process types) contributed by buildpacks like paketo-buildpacks/executable-jar and the packaged bytecode required as input to those buildpacks, provided by build system buildpacks like paketo-buildpacks/gradle.