### PR TITLE
Add settings.gradle[.kts] to files to detect

### DIFF
--- a/gradle/detect.go
+++ b/gradle/detect.go
@@ -36,6 +36,8 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 	files := []string{
 		filepath.Join(context.Application.Path, "build.gradle"),
 		filepath.Join(context.Application.Path, "build.gradle.kts"),
+		filepath.Join(context.Application.Path, "settings.gradle"),
+		filepath.Join(context.Application.Path, "settings.gradle.kts"),
 	}
 
 	for _, file := range files {

--- a/gradle/detect_test.go
+++ b/gradle/detect_test.go
@@ -92,4 +92,43 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		}))
 	})
 
+	it("passes with settings.gradle", func() {
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "settings.gradle"), []byte{}, 0644))
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "gradle"},
+						{Name: "jvm-application-package"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "gradle"},
+						{Name: "jdk"},
+					},
+				},
+			},
+		}))
+	})
+
+	it("passes with settings.gradle.kts", func() {
+		Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "settings.gradle.kts"), []byte{}, 0644))
+
+		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
+			Pass: true,
+			Plans: []libcnb.BuildPlan{
+				{
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "gradle"},
+						{Name: "jvm-application-package"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "gradle"},
+						{Name: "jdk"},
+					},
+				},
+			},
+		}))
+	})
 }


### PR DESCRIPTION
## Summary
Add settings.gradle[.kts] to files to detect if it is a Gradle project.

## Use Cases
In a multi-module project it is possible to change the names of all the build files. This is for example used to make it easier to jump to the correct file in an editor, i.e. instead of having many `build.gradle.kts` files, you can have a unique name for each based on the module name.

These names will be configured in a `settings.gradle[.kts]` file in the root of the project, so to support Gradle projects doing this just add these files to the list of files used for detecting a Gradle project.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
