### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/gradle`
 
-The Paketo Gradle Buildpack is a Cloud Native Buildpack that build Gradle-based applications from source.
+The Paketo Buildpack for Gradle is a Cloud Native Buildpack that build Gradle-based applications from source.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/gradle"
   id = "paketo-buildpacks/gradle"
   keywords = ["java", "gradle", "build-systems"]
-  name = "Paketo Gradle Buildpack"
+  name = "Paketo Buildpack for Gradle"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Gradle Buildpack' to 'Paketo Buildpack for Gradle'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
