### PR TITLE
Close #244: No more Gradle welcome message

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -33,7 +33,7 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
-    default = "--no-daemon assemble"
+    default = "--no-daemon -Dorg.gradle.welcome=never assemble"
     description = "the arguments to pass to Gradle"
     name = "BP_GRADLE_BUILD_ARGUMENTS"
 

--- a/gradle/build_test.go
+++ b/gradle/build_test.go
@@ -216,7 +216,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("BP_GRADLE_BUILD_ARGUMENTS env var is set", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_GRADLE_BUILD_ARGUMENTS", "--no-daemon assemble")).To(Succeed())
+			Expect(os.Setenv("BP_GRADLE_BUILD_ARGUMENTS", "--no-daemon -Dorg.gradle.welcome=never assemble")).To(Succeed())
 		})
 
 		it.After(func() {
@@ -229,7 +229,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(result.Layers[1].(libbs.Application).Arguments).To(Equal([]string{
-				"--no-daemon", "assemble",
+				"--no-daemon", "-Dorg.gradle.welcome=never", "assemble",
 			}))
 		})
 	})


### PR DESCRIPTION
## Summary
No more Gradle welcome message ; this closes Issue #244 

This option appeared in [Gradle 7.5](https://docs.gradle.org/7.5/release-notes.html#new-features-and-usability-improvements) (https://github.com/gradle/gradle/pull/18830).

I tried with an earlier version, 7.4, and while the welcome message was still shown, Gradle happily continued building (just to say this additional argument does not harm previous versions)

## Use Cases

It used to be:

```
> pack build applications/app
[...]
   Creating cache directory /home/cnb/.gradle
  Compiled Application: Contributing to layer
    Executing gradlew --no-daemon assemble
      Downloading https://services.gradle.org/distributions/gradle-7.6-bin.zip
      ...........10%............20%...........30%............40%............50%...........60%............70%............80%...........90%............100%
      
      Welcome to Gradle 7.6!
      
      Here are the highlights of this release:
       - Added support for Java 19.
       - Introduced `--rerun` flag for individual task rerun.
       - Improved dependency block for test suites to be strongly typed.
       - Added a pluggable system for Java toolchains provisioning.
      
      For more details see https://docs.gradle.org/7.6/release-notes.html
      
      To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.6/userguide/gradle_daemon.html#sec:disabling_the_daemon.
[...]
```

Then, it will be:


```
 pack build applications/native-image6 \
  -b urn:cnb:builder:paketo-buildpacks/ca-certificates \
  -b urn:cnb:builder:paketo-buildpacks/bellsoft-liberica \
  -b urn:cnb:builder:paketo-buildpacks/syft \
  -b anthonydahanne/gradle:fix-244 \
  -b urn:cnb:builder:paketo-buildpacks/executable-jar -b urn:cnb:builder:paketo-buildpacks/spring-boot -b urn:cnb:builder:paketo-buildpacks/native-image  --env BP_NATIVE_IMAGE=true
[...]
    Creating cache directory /home/cnb/.gradle
  Compiled Application: Contributing to layer
    Executing gradlew --no-daemon -Dorg.gradle.welcome=never assemble
      Downloading https://services.gradle.org/distributions/gradle-7.6-bin.zip
      ...........10%............20%...........30%............40%............50%...........60%............70%............80%...........90%............100%
      To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.6/userguide/gradle_daemon.html#sec:disabling_the_daemon.
      Daemon will be stopped at the end of the build 
[...]

```


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
