### PR TITLE
Close #259: Customize gradle-wrapper.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ The buildpack optionally accepts the following bindings:
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `gradle.properties` | If present, the contents of the file are copied to `$GRADLE_USER_HOME/gradle.properties` which is [picked up by gradle and merged](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties) when it runs. |
 
+### Type: `gradle-wrapper`
+
+| Secret                      | Description                                                                                                                                                                                                                                                                  |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gradle-wrapper.properties` | If present, the values of the properties file override the default ones found at <APPLICATION_ROOT>/gradle/wrapper/gradle-wrapper.properties which is [picked up by the gradle wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html#customizing_wrapper).  |
+
+
 ### Type: `dependency-mapping`
 
 | Key                   | Value   | Description                                                                                       |

--- a/gradle/build.go
+++ b/gradle/build.go
@@ -133,7 +133,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if binding, ok, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("gradle")); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding\n%w", err)
 	} else if ok {
-		b.Logger.Body("binding of type gradle successfully detected, configuring layer")
+		b.Logger.Debug("binding of type gradle successfully detected, configuring layer")
 		gradlePropertiesPath, ok := binding.SecretFilePath("gradle.properties")
 		if ok {
 			gradlePropertiesFile, err := os.Open(gradlePropertiesPath)
@@ -161,7 +161,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if binding, ok, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("gradle-wrapper")); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding\n%w", err)
 	} else if ok {
-		b.Logger.Body("binding of type gradle-wrapper successfully detected, configuring layer")
+		b.Logger.Debug("binding of type gradle-wrapper successfully detected, configuring layer")
 		gradleWrapperPropertiesPath, ok := binding.SecretFilePath("gradle-wrapper.properties")
 		if ok {
 			gradleWrapperPropertiesFile, err := os.Open(gradleWrapperPropertiesPath)

--- a/gradle/build.go
+++ b/gradle/build.go
@@ -133,6 +133,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if binding, ok, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("gradle")); err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding\n%w", err)
 	} else if ok {
+		b.Logger.Body("binding of type gradle successfully detected, configuring layer")
 		gradlePropertiesPath, ok := binding.SecretFilePath("gradle.properties")
 		if ok {
 			gradlePropertiesFile, err := os.Open(gradlePropertiesPath)
@@ -149,6 +150,37 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			result.Layers = append(result.Layers, PropertiesFile{
 				binding,
 				gradleHome,
+				"gradle.properties",
+				"gradle-properties",
+				b.Logger,
+			})
+		}
+	}
+
+	gradleWrapperHome := filepath.Join("gradle", "wrapper")
+	if binding, ok, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("gradle-wrapper")); err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding\n%w", err)
+	} else if ok {
+		b.Logger.Body("binding of type gradle-wrapper successfully detected, configuring layer")
+		gradleWrapperPropertiesPath, ok := binding.SecretFilePath("gradle-wrapper.properties")
+		if ok {
+			gradleWrapperPropertiesFile, err := os.Open(gradleWrapperPropertiesPath)
+			if err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to open gradle-wrapper.properties\n%w", err)
+			}
+
+			hasher := sha256.New()
+			if _, err := io.Copy(hasher, gradleWrapperPropertiesFile); err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to hash gradle-wrapper.properties\n%w", err)
+			}
+			md["gradle-wrapper-properties-sha256"] = hex.EncodeToString(hasher.Sum(nil))
+
+			result.Layers = append(result.Layers, PropertiesFile{
+				binding,
+				gradleWrapperHome,
+				"gradle-wrapper.properties",
+				"gradle-wrapper-properties",
+				b.Logger,
 			})
 		}
 	}

--- a/gradle/gradle_properties.go
+++ b/gradle/gradle_properties.go
@@ -2,6 +2,8 @@ package gradle
 
 import (
 	"fmt"
+	"github.com/magiconair/properties"
+	"github.com/paketo-buildpacks/libpak/bard"
 	"os"
 	"path/filepath"
 
@@ -9,34 +11,56 @@ import (
 )
 
 type PropertiesFile struct {
-	Binding    libcnb.Binding
-	GradleHome string
+	Binding                  libcnb.Binding
+	GradlePropertiesHome     string
+	GradlePropertiesFileName string
+	GradlePropertiesName     string
+	Logger                   bard.Logger
 }
 
 func (p PropertiesFile) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
-	path, ok := p.Binding.SecretFilePath("gradle.properties")
+	path, ok := p.Binding.SecretFilePath(p.GradlePropertiesFileName)
 	if !ok {
 		return libcnb.Layer{}, nil
 	}
 
-	gradlePropertiesPath := filepath.Join(p.GradleHome, "gradle.properties")
-	if err := os.Symlink(path, gradlePropertiesPath); os.IsExist(err) {
-		err = os.Remove(gradlePropertiesPath)
-		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to remove old symlink for gradle.properties\n%w", err)
-		}
+	originalPropertiesFilePath := filepath.Join(p.GradlePropertiesHome, p.GradlePropertiesFileName)
+	if p.GradlePropertiesName == "gradle-properties" {
+		p.Logger.Body("symlinking gradle-properties bound file")
+		gradlePropertiesPath := originalPropertiesFilePath
+		if err := os.Symlink(path, gradlePropertiesPath); os.IsExist(err) {
+			err = os.Remove(gradlePropertiesPath)
+			if err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to remove old symlink for %s\n%w", p.GradlePropertiesFileName, err)
+			}
 
-		err = os.Symlink(path, gradlePropertiesPath)
-		if err != nil {
-			return libcnb.Layer{}, fmt.Errorf("unable to create symlink for gradle.properties on retry\n%w", err)
+			err = os.Symlink(path, gradlePropertiesPath)
+			if err != nil {
+				return libcnb.Layer{}, fmt.Errorf("unable to create symlink for %s on retry\n%w", p.GradlePropertiesFileName, err)
+			}
+		} else if err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to symlink bound %s\n%w", p.GradlePropertiesFileName, err)
 		}
-	} else if err != nil {
-		return libcnb.Layer{}, fmt.Errorf("unable to symlink bound gradle.properties\n%w", err)
+	} else if p.GradlePropertiesName == "gradle-wrapper-properties" {
+		file, err := os.ReadFile(path)
+		if err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to read bound gradle-wrapper.properties file at %s\n%w", path, err)
+		}
+		p.Logger.Bodyf("applying these bound gradle-wrapper-properties to default one: \n%s\n", string(file))
+		mergedProperties := properties.MustLoadFiles([]string{originalPropertiesFilePath, path}, properties.UTF8, true)
+		propertiesFile, err := os.Create(originalPropertiesFilePath)
+		if err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to create/update original gradle-wrapper.properties file at %s\n%w", originalPropertiesFilePath, err)
+		}
+		_, err = mergedProperties.Write(propertiesFile, properties.UTF8)
+		if err != nil {
+			return libcnb.Layer{}, fmt.Errorf("unable to merge gradle-wrapper.properties files.\n%w", err)
+		}
 	}
 
 	return layer, nil
 }
 
 func (p PropertiesFile) Name() string {
-	return "gradle-properties"
+	return p.GradlePropertiesName
 }

--- a/gradle/gradle_properties.go
+++ b/gradle/gradle_properties.go
@@ -26,7 +26,7 @@ func (p PropertiesFile) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 
 	originalPropertiesFilePath := filepath.Join(p.GradlePropertiesHome, p.GradlePropertiesFileName)
 	if p.GradlePropertiesName == "gradle-properties" {
-		p.Logger.Body("symlinking gradle-properties bound file")
+		p.Logger.Debug("symlinking gradle-properties bound file")
 		gradlePropertiesPath := originalPropertiesFilePath
 		if err := os.Symlink(path, gradlePropertiesPath); os.IsExist(err) {
 			err = os.Remove(gradlePropertiesPath)
@@ -46,7 +46,7 @@ func (p PropertiesFile) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 		if err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to read bound gradle-wrapper.properties file at %s\n%w", path, err)
 		}
-		p.Logger.Bodyf("applying these bound gradle-wrapper-properties to default one: \n%s\n", string(file))
+		p.Logger.Debugf("applying these bound gradle-wrapper-properties to default one: \n%s\n", string(file))
 		mergedProperties := properties.MustLoadFiles([]string{originalPropertiesFilePath, path}, properties.UTF8, true)
 		propertiesFile, err := os.Create(originalPropertiesFilePath)
 		if err != nil {

--- a/gradle/testdata/gradle-wrapper.properties
+++ b/gradle/testdata/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+networkTimeout=10000
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
* add new binding of type gradle-wrapper that allows the user to, for example, override the networkTimeout or distributionUrl.

## Use Cases
for example when default timeout is not enough to dwonlaod the gradle distribution zip, of if the user wants to doanlod the distribution zip from a different url than gradle default url.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
