### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/gradle/build.go
+++ b/gradle/build.go
@@ -193,7 +193,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		AdditionalHelpMessage:    "If this is unexpected, please try setting `rootProject.name` in `settings.gradle` or add a project.toml file and exclude the `build/` directory. For details see https://buildpacks.io/docs/app-developer-guide/using-project-descriptor/.",
 	}
 
-	bomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.NewExecutor(), b.Logger)
+	bomScanner := sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 	a, err := b.ApplicationFactory.NewApplication(
 		md,
 		args,

--- a/gradle/build_test.go
+++ b/gradle/build_test.go
@@ -62,6 +62,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			ApplicationFactory:    &FakeApplicationFactory{},
 			HomeDirectoryResolver: FakeHomeDirectoryResolver{path: homeDir},
 		}
+
+		t.Setenv("BP_ARCH", "amd64")
 	})
 
 	it.After(func() {

--- a/gradle/distribution_test.go
+++ b/gradle/distribution_test.go
@@ -17,7 +17,6 @@
 package gradle_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,7 +39,7 @@ func testDistribution(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "distribution-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "distribution-layers")
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
