### PR TITLE
Add s390x and ppc64le architecture support

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -121,3 +121,11 @@ api = "0.7"
 [[targets]]
   arch = "arm64"
   os = "linux"
+
+[[targets]]
+  arch = "s390x"
+  os = "linux"
+
+[[targets]]
+  arch = "ppc64le"
+  os = "linux"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds `s390x` and `ppc64le` architecture targets to `buildpack.toml`. No dependency entries or sha256 changes are needed as Gradle is distributed as architecture-independent archives.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Enables the Gradle buildpack to run on s390x and ppc64le Linux platforms, supporting Java application builds on IBM Z and IBM Power infrastructure.
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
